### PR TITLE
Add retry middleware to Faraday connection

### DIFF
--- a/lib/onesignal/http_client.rb
+++ b/lib/onesignal/http_client.rb
@@ -9,6 +9,7 @@ module Onesignal
       @app_id = app_id
       @connection = Faraday.new(url: URL) do |connection|
         connection.request :json
+        connection.request :retry
         connection.response :json, content_type: /\bjson$/
         connection.adapter Faraday.default_adapter
         connection.response :logger, log, bodies: true


### PR DESCRIPTION
Closes #33

By default, it retries two times and handles only timeout exceptions

https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb