### PR TITLE
Push test notifications to iOS sandbox

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,4 +32,5 @@ Onesignal.configure do |config|
   config.app_id = ENV['TEST_APP_ID']
   logger = Logger.new(File.new('tmp/test.log', 'w'))
   config.log = logger
+  config.ios_device_test_type = 2
 end


### PR DESCRIPTION
This is used in deciding whether to use your iOS Sandbox or Production push certificate when sending a push when both have been uploaded. Set to the iOS provisioning profile that was used to build your app. 1 = Development, 2 = Ad-Hoc. Omit this field for App Store builds. https://documentation.onesignal.com/docs/players-add-a-device